### PR TITLE
Fix unordered tracks when there's justifies

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class AhgoraVai {
     
       const row = $(element).parents('tr');
       const tracksTd = $(row).find('td:eq(2)');
-      let tracks = tracksTd.html();
+      let tracks = tracksTd.html().trim();
       if (tracks != '') {
           tracks += ', ';
       }


### PR DESCRIPTION
Because of spaces that were present in the HTML, the tracks were not getting properly ordered when there were justified tracks.

By using a timely `trim()` call we can get rid of this!