### PR TITLE
Ignore 'Horas Previstas: 08:48'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ahgora-vai",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "Chrome extension that give superpowers to Ahgora's time sheet page",
   "scripts": {
     "build": "webpack",

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ class AhgoraVai {
     let workload = this.parse(this.workload);
     let leave, started, leavingNow;
 
-    let worked = $(dayRow).find('td:eq(6)').text().replace('Horas Trabalhadas: ', '');
+    let worked = $(dayRow).find('td:eq(6)').text().replace('Horas Previstas: 08:48', '').replace('Horas Trabalhadas: ', '');
     if (worked != '') {
       worked = this.parse(worked);
       workload = this.subtract(workload, worked);


### PR DESCRIPTION
Table starts to show 'Horas Previstas: 08:48' each row and broked our 'today prevision'. We are just ignoring it.

![Screen Shot 2019-07-10 at 10 16 37](https://user-images.githubusercontent.com/45628539/60972097-f60c4100-a2fb-11e9-8c81-5493faecfbaa.png)
